### PR TITLE
Updated lodash dependency. Version bump to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oniyi-locker",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "The best module ever.",
   "author": {
     "name": "Benjamin Kroeger",
@@ -21,7 +21,7 @@
   "dependencies": {
     "async": "2.6.2",
     "ioredis": "3.2.1",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "oniyi-logger": "1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello,

I'm working on on a program analysis tool for some research and I noticed you are using version 4.17.11 of lodash.  `lodash@4.17.11` has a [vulnerability in the defaultsDeep method](https://www.npmjs.com/advisories/1065) which is used in this repository in `lib/index.js`.

This PR bumps the version of lodash to 4.17.15, the latest version as of this writing.  I saw that you pin all of your dependencies to specific versions and have respected that with this PR.

Let me know if you have any questions or would like to discuss further!  Thanks!